### PR TITLE
Add ShellCheck action to check installation scripts

### DIFF
--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -1,0 +1,16 @@
+on: [push, pull_request]
+
+name: 'Analyse shell scripts'
+
+jobs:
+  shellcheck:
+    name: ShellCheck
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Run ShellCheck
+      uses: ludeeus/action-shellcheck@master
+      with:
+        scandir: './installation-scripts'
+      env:
+        SHELLCHECK_OPTS: -x


### PR DESCRIPTION
Adds a ShellCheck GitHub action to check installation scripts in `installation-scripts/` for errors and warnings due to their importance.